### PR TITLE
Update Player.cs

### DIFF
--- a/Scripts/Characters/Player/Player.cs
+++ b/Scripts/Characters/Player/Player.cs
@@ -191,7 +191,8 @@ public class Player : Character
             StopCoroutine(moveCoroutine);
         }
 
-        moveCoroutine = StartCoroutine(MoveCoroutine(decelerationTime, Vector2.zero, Quaternion.identity));
+        moveDirection = Vector2.zero;
+        moveCoroutine = StartCoroutine(MoveCoroutine(decelerationTime, moveDirection, Quaternion.identity));
         StartCoroutine(nameof(DecelerationCoroutine));
     }
 


### PR DESCRIPTION
#3 修复玩家受击后的移动问题。

目前的做法是在执行`input.onStopMove`的回调`StopMove()`中，把 moveDirection 重置。

理论上还有一个方法，就是把玩家的移动方式从刚体改成使用`FixedUpdate()`或者`IEnumerator`修改玩家的 transform ，但需要修改的代码有点多，就不在这个仓库里pq了。